### PR TITLE
GPON: Manual headings for TOC sanity

### DIFF
--- a/docs/gpon/ont/fs/gpon-onu-34-20bi.md
+++ b/docs/gpon/ont/fs/gpon-onu-34-20bi.md
@@ -1,11 +1,14 @@
 # GPON-ONU-34-20BI
 
+## Specifications
+
 --8<-- "docs/gpon/ont/sp/sps-34-24t-hp-tdfo.md:specifications"
 
 ![Image of GPON-ONU-34-20BI](/img/gpon-onu-34-20bi.png){ align=center }
 
+## Login Credentials
+
 <!-- --8<-- [start:credentials] -->
-### Login Credentials
 === "SSH / UART"
     | Username | Password       |
     | -------- | -------------- |

--- a/docs/gpon/ont/huawei/ma5671a.md
+++ b/docs/gpon/ont/huawei/ma5671a.md
@@ -1,9 +1,12 @@
 # MA5671A
 
+## Specifications
+
 --8<-- "docs/gpon/ont/sp/sps-34-24t-hp-tdfo.md:specifications"
 
+## Login Credentials
+
 <!-- --8<-- [start:credentials] -->
-### Login Credentials
 === "SSH / UART"
     | Username | Password       |
     | -------- | -------------- |

--- a/docs/gpon/ont/nokia/g-010s-p.md
+++ b/docs/gpon/ont/nokia/g-010s-p.md
@@ -1,11 +1,14 @@
 # G-010S-P
 
+## Specifications
+
 --8<-- "docs/gpon/ont/sp/sps-34-24t-hp-tdfo.md:specifications"
 
 ![Image of G-010S-P](/img/g-010s-p.png){ align=center }
 
+## Login Credentials
+
 <!-- --8<-- [start:credentials] -->
-### Login Credentials
 === "SSH / UART"
     | Username | Password       |
     | -------- | -------------- |

--- a/docs/gpon/ont/sp/sps-34-24t-hp-tdfo.md
+++ b/docs/gpon/ont/sp/sps-34-24t-hp-tdfo.md
@@ -1,7 +1,8 @@
 # SPS-34-24T-HP-TDFO
 
-<!-- --8<-- [start:specifications] -->
 ## Specifications
+
+<!-- --8<-- [start:specifications] -->
 | Chipset         | Lantiq PEB98035      |
 | --------------- | -------------------- |
 | CPU             | MIPS 34Kc interAptiv |
@@ -20,11 +21,20 @@
 
 ## Vendor Specific
 
-## G-010S-P
+### G-010S-P
+
+#### Login Credentials
+
 --8<-- "docs/gpon/ont/nokia/g-010s-p.md:credentials"
 
-## GPON-ONU-34-20BI"
+### GPON-ONU-34-20BI
+
+#### Login Credentials
+
 --8<-- "docs/gpon/ont/fs/gpon-onu-34-20bi.md:credentials"
 
-## MA5671A
+### MA5671A
+
+#### Login Credentials
+
 --8<-- "docs/gpon/ont/huawei/ma5671a.md:credentials"


### PR DESCRIPTION
Move headings outside snippet blocks so the TOC isn't unmanagable
Correct typo