### PR TITLE
Fix URL to DZS homepage in was-110.md

### DIFF
--- a/docs/xgs-pon/ont/bfw-solutions/was-110.md
+++ b/docs/xgs-pon/ont/bfw-solutions/was-110.md
@@ -7,7 +7,7 @@
 | Company                                        | Product Number    | E-commerce                                  |
 | ---------------------------------------------- | ----------------- | ------------------------------------------- |
 | [Azores Networks](https://azoresnetworks.com/) | XSS               |                                             |
-| [DZS](https://dszi.com/)                       | 5311XP            |                                             |
+| [DZS](https://dzsi.com/)                       | 5311XP            |                                             |
 | [E.C.I. Networks](https://ecin.ca/)            | EN-XGSFPP-OMAC-V2 | :check_mark:                                |
 | [FiberMall](https://www.fibermall.com/)        | XGSPON-ONU-STICK  | :check_mark:                                |
 | [HALNy Networks](https://halny.com/)           | HLX-SFPX          | Available from [Flytec Computers] :flag_us: |


### PR DESCRIPTION
The URL to the homepage of DZS in `was-110.md` is incorrect. This pull request fixes the link so it links to the homepage properly.