### PR TITLE
post 6: add form-factor warning

### DIFF
--- a/docs/posts/masquerade-as-the-frontier-comms-inc-fox222-frx523-with-the-bfw-solutions-was-110.md
+++ b/docs/posts/masquerade-as-the-frontier-comms-inc-fox222-frx523-with-the-bfw-solutions-was-110.md
@@ -15,6 +15,8 @@ slug: masquerade-as-the-frontier-comms-inc-fox222-frx523-with-the-bfw-solutions-
 
 # Masquerade as the Frontier Communications Inc. FOX222 or FRX523 with the BFW Solutions WAS-110
 
+!!! warning "This is strictly for the form-factor as they're both SFU ONTs"
+
 ![Bypass family](masquerade-as-the-frontier-comms-inc-fox222-frx523-with-the-bfw-solutions-was-110/bypass_fox222_frx523.webp){ class="nolightbox" }
 
 <!-- more -->


### PR DESCRIPTION
I added the form-factor disclaimer for consistency, like in the XS-010X-Q guide.

For consistency consider the term "Swap out" instead of "Masquerade as" in the title/description/slug, i.e. "Swap out the Frontier Communications Inc. FOX222 or FRX523 for a Small Form-factor Pluggable BFW Solutions WAS-110". But that's up to you since I don't want to change titles just for the sake of changing titles.