### PR TITLE
docs: add GigaHub 2.14 firmware version info

### DIFF
--- a/docs/posts/masquerade-as-the-bce-inc-giga-hub-with-the-was-110.md
+++ b/docs/posts/masquerade-as-the-bce-inc-giga-hub-with-the-was-110.md
@@ -283,6 +283,7 @@ but it is not strictly necessary.
 
 | Firmware Version | External Firmware Version |
 | ---------------- | ------------------------- |
+| 2.14             | SGC84000DC                |
 | 2.13             | SGC84000AE                |
 | 2.11             | SGC8400078                |
 | 2.9              | SGC8400058                |


### PR DESCRIPTION
Add GigaHub 2.14 firmware version info:

```
$ xmo-remote-client get-value --path "Device/DeviceInfo/SoftwareVersion" --path "Device/DeviceInfo/ExternalFirmwareVersion"
Password: 
Repeat for confirmation: 
"2.14"
"SGC84000DC"
```