### PR TITLE
docs: add GigaHub 2.14.1 firmware

### DIFF
--- a/docs/posts/masquerade-as-the-bce-inc-giga-hub-with-the-was-110/versions.csv
+++ b/docs/posts/masquerade-as-the-bce-inc-giga-hub-with-the-was-110/versions.csv
@@ -1,4 +1,5 @@
 Firmware Version,External Firmware Version
+2.14.1,SGC84000E0
 2.14,SGC84000DC
 2.13,SGC84000AE
 2.11,SGC8400078


### PR DESCRIPTION
Recently did the GigaHub bypass. This was the reported firmware version of the GigaHub at the time of the bypass.