### PR TITLE
docs: add additional Orange Livebox 7 software versions

### DIFF
--- a/docs/posts/masquerade-as-the-orange-sa-livebox-7-with-the-was-110.md
+++ b/docs/posts/masquerade-as-the-orange-sa-livebox-7-with-the-was-110.md
@@ -218,6 +218,7 @@ the Livebox 7, which uses CWMP[^2]. However, it is recommended to keep somewhat 
 
 | Software Version 0 | Software Version 1 |
 | ------------------ | ------------------ |
+| SAHEOFR030502      | SAHEOFR030602      |
 | SAHEOFR070202      | SAHEOFR919117      |
 | SAHEOFR010117      | SAHEOFR070101      |
 | SAHEOFR010113      |                    |


### PR DESCRIPTION
Adding some newer Livebox 7 software versions values.

<img width="2103" height="101" alt="image" src="https://github.com/user-attachments/assets/925e2db0-613e-4369-a9ca-677fed8041ce" />
